### PR TITLE
passphrase_check_method properly handle null column value

### DIFF
--- a/lib/DBIx/Class/PassphraseColumn.pm
+++ b/lib/DBIx/Class/PassphraseColumn.pm
@@ -178,7 +178,8 @@ sub register_column {
         if (defined(my $meth = $info->{passphrase_check_method})) {
             my $checker = sub {
                 my ($row, $val) = @_;
-                return $row->get_inflated_column($column)->match($val);
+                my $ppr = $row->get_inflated_column($column) or return 0;
+                return $ppr->match($val);
             };
 
             my $name = join q[::] => $self->result_class, $meth;


### PR DESCRIPTION
When the column value is null, ->get_inflated_column returns undef and not an Authen::Passphrase object. Instead of throwing an exception, this change just fails the check like any other incorrect password